### PR TITLE
Fixes to advanced_example

### DIFF
--- a/advanced_examples/CMakeLists.txt.in
+++ b/advanced_examples/CMakeLists.txt.in
@@ -1,14 +1,13 @@
 cmake_minimum_required(VERSION 3.15)
-
-list(APPEND CMAKE_PREFIX_PATH $ENV{APB})
-
 project(@UP_NAME@ CXX)
+
+include("${CMAKE_SOURCE_DIR}/../../CMake/GetAutoPybind11.cmake")
+
 find_package(AutoPyBind11)
-autopybind_fetch_build_pybind11(PYBIND11_DIR ${PYBIND11_DIR})
 
 add_library(@MOD_NAME@ INTERFACE)
 target_include_directories(@MOD_NAME@ INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-target_add_sources(@MOD_NAME@ INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/@MOD_NAME@.hpp)
+target_sources(@MOD_NAME@ INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/@MOD_NAME@.hpp)
 
 
 autopybind11_add_module(@MOD_NAME@MOD

--- a/advanced_examples/advanced_examples.ipynb
+++ b/advanced_examples/advanced_examples.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "visualize_binding_code(example_directory)"
+    "visualize_binding_code(\"%sMOD.cpp\" % example_directory)"
    ]
   },
   {


### PR DESCRIPTION
Fetch autopybind11 directly instead of relying on it existing elsewhere.
Use "target_sources" instead of target_add_sources

Don't pass a directory name to the final display, but instead a known
file name.